### PR TITLE
Add stdio options to spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ functionality:
   - **exit(code?: number): void** - Terminates the process with control over the
     exit code.
 
-* **@cross/utils/format**
+- **@cross/utils/format**
   - **table(data: string[][]): void** - Generates a neatly formatted table
     representation of a 2D array and prints it to the console.
     - **Parameter:**
@@ -221,3 +221,11 @@ functionality:
   sealedCopy.w = 7; // Throws an error in strict mode
   original.w = 20; // Succeeds, original is unchanged
   ```
+  
+- **@cross/utils/stdio**
+  - **stdin(): ReadableStream**
+    - Get the stdin as a web-standard `ReadableStream` object.
+  - **stdout(): WritableStream**
+    - Get the stdout as a web-standard `WritableStream` object.
+  - **stderr(): WritableStream**
+    - Get the stderr as a web-standard `WritableStream` object.

--- a/README.md
+++ b/README.md
@@ -58,12 +58,22 @@ bunx jsr add @cross/utils
     any modifications to the object's properties.
   - If `createCopy` is `true` (default is `false`), a new frozen deep copy of
     the object is returned, leaving the original unchanged.
+
 - **deepSeal<T>(obj: T, createCopy?: boolean): T**
   - Recursively seals an object and all its nested objects. Sealing prevents new
     properties from being added or removed, but existing properties can still be
     modified.
   - If `createCopy` is `true` (default is `false`), a new sealed deep copy of
     the object is returned, leaving the original unchanged.
+
+- **stdin(): ReadableStream**
+  - Get the stdin as a web-standard `ReadableStream` object.
+
+- **stdout(): WritableStream**
+  - Get the stdout as a web-standard `WritableStream` object.
+
+- **stderr(): WritableStream**
+  - Get the stderr as a web-standard `WritableStream` object.
 
 **Classes**
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ bunx jsr add @cross/utils
 - **stripAnsi(text: string): string**
   - Removes all ANSI control codes from a string for cleaner logs and output.
 
-- **spawn(command: CommandArray, extraEnvVars?: Object, cwd?: string, stdio: StdIO)**
+- **spawn(command: CommandArray, extraEnvVars?: Object, cwd?: string, stdio:
+  StdIO)**
   - Spawns a sub process.
 
 - **table(data: string[][])**
@@ -136,8 +137,8 @@ functionality:
   - **Colors Class** - Provides methods for easy console text styling.
 
 - **@cross/utils/spawn**
-  - **spawn(command: CommandArray, extraEnvVars?: Object, cwd?: string, stdio: StdIO):
-    Promise<>** - Spawns subprocesses in a cross-runtime manner.
+  - **spawn(command: CommandArray, extraEnvVars?: Object, cwd?: string, stdio:
+    StdIO): Promise<>** - Spawns subprocesses in a cross-runtime manner.
 
 - **@cross/utils/args**
   - **args(all?: boolean): string[]** - Fetches command-line arguments
@@ -221,7 +222,7 @@ functionality:
   sealedCopy.w = 7; // Throws an error in strict mode
   original.w = 20; // Succeeds, original is unchanged
   ```
-  
+
 - **@cross/utils/stdio**
   - **stdin(): ReadableStream**
     - Get the stdin as a web-standard `ReadableStream` object.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ bunx jsr add @cross/utils
 - **stripAnsi(text: string): string**
   - Removes all ANSI control codes from a string for cleaner logs and output.
 
-- **spawn(command: CommandArray, extraEnvVars?: Object, cwd?: string)**
+- **spawn(command: CommandArray, extraEnvVars?: Object, cwd?: string, stdio: StdIO)**
   - Spawns a sub process.
 
 - **table(data: string[][])**
@@ -126,7 +126,7 @@ functionality:
   - **Colors Class** - Provides methods for easy console text styling.
 
 - **@cross/utils/spawn**
-  - **spawn(command: CommandArray, extraEnvVars?: Object, cwd?: string):
+  - **spawn(command: CommandArray, extraEnvVars?: Object, cwd?: string, stdio: StdIO):
     Promise<>** - Spawns subprocesses in a cross-runtime manner.
 
 - **@cross/utils/args**

--- a/deno.json
+++ b/deno.json
@@ -11,7 +11,8 @@
     "./table": "./utils/table.ts",
     "./execpath": "./utils/execpath.ts",
     "./sysinfo": "./utils/sysinfo.ts",
-    "./objectManip": "./utils/objectManip.ts"
+    "./objectManip": "./utils/objectManip.ts",
+    "./stdio": "./utils/stdio.ts"
   },
   "imports": {
     "@cross/fs": "jsr:@cross/fs@^0.1.11",

--- a/mod.ts
+++ b/mod.ts
@@ -14,3 +14,4 @@ export {
   uptime,
 } from "./utils/sysinfo.ts";
 export { deepFreeze, deepSeal } from "./utils/objectManip.ts";
+export { stdin, stdout, stderr } from "./utils/stdio.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -3,7 +3,7 @@ export { pid } from "./utils/pid.ts";
 export { args, ArgsParser } from "./utils/args.ts";
 export { Colors, Cursor, stripAnsi } from "./utils/ansi.ts";
 export { spawn } from "./utils/spawn.ts";
-export type { SpawnResult } from "./utils/spawn.ts";
+export type { SpawnResult, SpawnStdIO } from "./utils/spawn.ts";
 export { execPath, resolvedExecPath } from "./utils/execpath.ts";
 export {
   loadAvg,

--- a/mod.ts
+++ b/mod.ts
@@ -14,4 +14,4 @@ export {
   uptime,
 } from "./utils/sysinfo.ts";
 export { deepFreeze, deepSeal } from "./utils/objectManip.ts";
-export { stdin, stdout, stderr } from "./utils/stdio.ts";
+export { stderr, stdin, stdout } from "./utils/stdio.ts";

--- a/utils/args.ts
+++ b/utils/args.ts
@@ -1,4 +1,5 @@
 import { CurrentRuntime, Runtime } from "@cross/runtime";
+import process from "node:process";
 
 /**
  * Retrieves command-line arguments in a cross-runtime compatible manner.

--- a/utils/execpath.ts
+++ b/utils/execpath.ts
@@ -1,5 +1,6 @@
 import { CurrentRuntime, Runtime } from "@cross/runtime";
 import { which } from "@cross/fs/stat";
+import process from "node:process";
 
 /**
  * Cross-runtime compatible way to return the current executable path in a  manner, regardless of Node, Deno or Bun.

--- a/utils/exit.ts
+++ b/utils/exit.ts
@@ -1,4 +1,5 @@
 import { CurrentRuntime, Runtime } from "@cross/runtime";
+import process from "node:process";
 
 /**
  * Terminates the current process in a cross-runtime compatible manner.

--- a/utils/pid.ts
+++ b/utils/pid.ts
@@ -1,4 +1,5 @@
 import { CurrentRuntime, Runtime } from "@cross/runtime";
+import process from "node:process";
 
 /**
  * Return the current process pid in a cross-runtime compatible manner.

--- a/utils/spawn.ts
+++ b/utils/spawn.ts
@@ -46,17 +46,17 @@ export interface StdIO {
   /**
    * The input into the spawned process.
    */
-  stdin: ReadableStream | null;
+  stdin: ReadableStream | "inherit" | null;
 
   /**
    * The output from the spawned process.
    */
-  stdout: WritableStream | null;
+  stdout: WritableStream | "inherit" | null;
 
   /**
    * The errors from the spawned process.
    */
-  stderr: WritableStream | null;
+  stderr: WritableStream | "inherit" | null;
 }
 
 /**
@@ -106,10 +106,10 @@ export function spawn(
     }
   }
 
-  const stdio_node: ("pipe" | "ignore")[] = [
-    stdio.stdin ? "pipe" : "ignore",
-    stdio.stdout ? "pipe" : "ignore",
-    stdio.stderr ? "pipe" : "ignore"
+  const stdio_node: ("pipe" | "inherit" | "ignore")[] = [
+    stdio.stdin === "inherit" ? "inherit" : stdio.stdin ? "pipe" : "ignore",
+    stdio.stdout === "inherit" ? "inherit" : stdio.stdout ? "pipe" : "ignore",
+    stdio.stderr === "inherit" ? "inherit" : stdio.stderr ? "pipe" : "ignore"
   ];
 
   const childProcess = spawnChild(
@@ -124,11 +124,11 @@ export function spawn(
   );
 
   // @ts-ignore Node's types here are weird
-  if (stdio.stdin) Readable.fromWeb(stdio.stdin).pipe(childProcess.stdin, { end: false });
+  if (stdio.stdin instanceof ReadableStream) Readable.fromWeb(stdio.stdin).pipe(childProcess.stdin, { end: false });
   // @ts-ignore Node's types here are weird
-  if (stdio.stdout) childProcess.stdout.pipe(Writable.fromWeb(stdio.stdout), { end: false });
+  if (stdio.stdout instanceof WritableStream) childProcess.stdout.pipe(Writable.fromWeb(stdio.stdout), { end: false });
   // @ts-ignore Node's types here are weird
-  if (stdio.stderr) childProcess.stderr.pipe(Writable.fromWeb(stdio.stderr), { end: false });
+  if (stdio.stderr instanceof WritableStream) childProcess.stderr.pipe(Writable.fromWeb(stdio.stderr), { end: false });
 
   return new Promise((resolve, reject) => { // Still need Promise here due to event listeners
     childProcess.on("error", (error: Error) => reject(error));

--- a/utils/spawn.ts
+++ b/utils/spawn.ts
@@ -15,7 +15,7 @@ if (CurrentRuntime === Runtime.Bun) {
         writer.write(chunk);
       },
     });
-  }
+  };
 }
 
 /**
@@ -98,18 +98,22 @@ export function spawn(
     stdio = {
       stdin: null,
       stdout: new WritableStream({
-        write(chunk) {stdoutBuffer += chunk.toString()},
+        write(chunk) {
+          stdoutBuffer += chunk.toString();
+        },
       }),
       stderr: new WritableStream({
-        write(chunk) {stderrBuffer += chunk.toString()},
+        write(chunk) {
+          stderrBuffer += chunk.toString();
+        },
       }),
-    }
+    };
   }
 
   const stdio_node: ("pipe" | "inherit" | "ignore")[] = [
     stdio.stdin === "inherit" ? "inherit" : stdio.stdin ? "pipe" : "ignore",
     stdio.stdout === "inherit" ? "inherit" : stdio.stdout ? "pipe" : "ignore",
-    stdio.stderr === "inherit" ? "inherit" : stdio.stderr ? "pipe" : "ignore"
+    stdio.stderr === "inherit" ? "inherit" : stdio.stderr ? "pipe" : "ignore",
   ];
 
   const childProcess = spawnChild(
@@ -123,18 +127,27 @@ export function spawn(
     },
   );
 
-  // @ts-ignore Node's types here are weird
-  if (stdio.stdin instanceof ReadableStream) Readable.fromWeb(stdio.stdin).pipe(childProcess.stdin, { end: false });
-  // @ts-ignore Node's types here are weird
-  if (stdio.stdout instanceof WritableStream) childProcess.stdout.pipe(Writable.fromWeb(stdio.stdout), { end: false });
-  // @ts-ignore Node's types here are weird
-  if (stdio.stderr instanceof WritableStream) childProcess.stderr.pipe(Writable.fromWeb(stdio.stderr), { end: false });
+  if (stdio.stdin instanceof ReadableStream) {
+    // @ts-ignore Node's types here are weird
+    Readable.fromWeb(stdio.stdin).pipe(childProcess.stdin, { end: false });
+  }
+
+  if (stdio.stdout instanceof WritableStream) {
+    // @ts-ignore Node's types here are weird
+    childProcess.stdout.pipe(Writable.fromWeb(stdio.stdout), { end: false });
+  }
+
+  if (stdio.stderr instanceof WritableStream) {
+    // @ts-ignore Node's types here are weird
+    childProcess.stderr.pipe(Writable.fromWeb(stdio.stderr), { end: false });
+  }
 
   return new Promise((resolve, reject) => { // Still need Promise here due to event listeners
     childProcess.on("error", (error: Error) => reject(error));
     childProcess.on(
       "close",
-      (code: number) => resolve({ code, stdout: stdoutBuffer, stderr: stderrBuffer }),
+      (code: number) =>
+        resolve({ code, stdout: stdoutBuffer, stderr: stderrBuffer }),
     );
   });
 }

--- a/utils/spawn.ts
+++ b/utils/spawn.ts
@@ -123,14 +123,12 @@ export function spawn(
     },
   );
 
-  console.log(Readable.fromWeb, Writable.fromWeb)
-
   // @ts-ignore Node's types here are weird
-  if (stdio.stdin) Readable.fromWeb(stdio.stdin).pipe(childProcess.stdin);
+  if (stdio.stdin) Readable.fromWeb(stdio.stdin).pipe(childProcess.stdin, { end: false });
   // @ts-ignore Node's types here are weird
-  if (stdio.stdout) childProcess.stdout.pipe(Writable.fromWeb(stdio.stdout));
+  if (stdio.stdout) childProcess.stdout.pipe(Writable.fromWeb(stdio.stdout), { end: false });
   // @ts-ignore Node's types here are weird
-  if (stdio.stderr) childProcess.stderr.pipe(Writable.fromWeb(stdio.stderr));
+  if (stdio.stderr) childProcess.stderr.pipe(Writable.fromWeb(stdio.stderr), { end: false });
 
   return new Promise((resolve, reject) => { // Still need Promise here due to event listeners
     childProcess.on("error", (error: Error) => reject(error));

--- a/utils/spawn.ts
+++ b/utils/spawn.ts
@@ -21,11 +21,33 @@ export interface SpawnResult {
   stderr: string;
 }
 
+/**
+ * Use to pass stdin, stdout and stderr to spawn() instead of getting all the
+ * text at the end.
+ */
+export interface StdIO {
+  /**
+   * The input into the spawned process.
+   */
+  stdin: ReadableStream;
+
+  /**
+   * The output from the spawned process.
+   */
+  stdout: WritableStream;
+
+  /**
+   * The errors from the spawned process.
+   */
+  stderr: WritableStream;
+}
+
 // Runtime-specific execution functions (also using async/await)
 async function spawnNodeChildProcess(
   command: string[],
   env: Record<string, string> = {},
   cwd?: string,
+  stdio?: StdIO
 ): Promise<SpawnResult> {
   const { spawn } = await import("node:child_process");
   //@ts-ignore Node specific
@@ -60,6 +82,7 @@ async function spawnDenoChildProcess(
   command: string[],
   env: Record<string, string> = {},
   cwd?: string,
+  stdio?: StdIO
 ): Promise<SpawnResult> {
   // @ts-ignore Deno is specific to Deno
   const options: Deno.CommandOptions = {
@@ -80,6 +103,7 @@ async function spawnBunChildProcess(
   command: string[],
   extraEnvVars: Record<string, string> = {},
   cwd?: string,
+  stdio?: StdIO
 ): Promise<SpawnResult> {
   // @ts-ignore Bun is runtime specific
   const results = await Bun.spawn({

--- a/utils/spawn.ts
+++ b/utils/spawn.ts
@@ -42,7 +42,7 @@ export interface SpawnResult {
  * Use to pass stdin, stdout and stderr to spawn() instead of getting all the
  * text at the end.
  */
-export interface StdIO {
+export interface SpawnStdIO {
   /**
    * The input into the spawned process.
    */
@@ -89,7 +89,7 @@ export function spawn(
   command: string[],
   env: Record<string, string> = {},
   cwd?: string,
-  stdio?: StdIO,
+  stdio?: SpawnStdIO,
 ): Promise<SpawnResult> {
   let stdoutBuffer = "";
   let stderrBuffer = "";

--- a/utils/spawn.ts
+++ b/utils/spawn.ts
@@ -7,7 +7,7 @@ import process from "node:process";
 
 if (CurrentRuntime === Runtime.Bun) {
   // Bun has a bug in Writable.fromWeb, so polyfill
-  Writable.fromWeb = (writableStream: WritableStream) => {
+  Writable.fromWeb = (writableStream) => {
     const writer = writableStream.getWriter();
 
     return new Writable({

--- a/utils/spawn.ts
+++ b/utils/spawn.ts
@@ -1,5 +1,4 @@
 import { CurrentRuntime, Runtime } from "@cross/runtime";
-import { writeFile } from "@cross/fs/io";
 import process from "node:process";
 
 /**
@@ -174,10 +173,11 @@ async function spawnBunChildProcess(
  * @param {string[]} command - An array of strings representing the command and its arguments.
  * @param {Record<string, string>} [extraEnvVars] - An optional object containing additional environment variables to set for the command.
  * @param {string} [cwd] - An optional path specifying the current working directory for the command.
+ * @param {StdIO} [stdio] - An optional object specifying streams to use instead of buffering the output.
  * @returns {Promise<SpawnResult>} A Promise resolving with an object containing:
  *   * code: The exit code of the executed command.
- *   * stdout: The standard output of the command.
- *   * stderr: The standard error of the command.
+ *   * stdout: The standard output of the command (empty if stdio argument supplied).
+ *   * stderr: The standard error of the command (empty if stdio argument supplied).
  *
  * @throws {Error} If the current runtime is not supported.
  *
@@ -197,14 +197,15 @@ export async function spawn(
   command: string[],
   extraEnvVars: Record<string, string> = {},
   cwd?: string,
+  stdio?: StdIO,
 ): Promise<SpawnResult> {
   switch (CurrentRuntime) {
     case Runtime.Node:
-      return await spawnNodeChildProcess(command, extraEnvVars, cwd);
+      return await spawnNodeChildProcess(command, extraEnvVars, cwd, stdio);
     case Runtime.Deno:
-      return await spawnDenoChildProcess(command, extraEnvVars, cwd);
+      return await spawnDenoChildProcess(command, extraEnvVars, cwd, stdio);
     case Runtime.Bun:
-      return await spawnBunChildProcess(command, extraEnvVars, cwd);
+      return await spawnBunChildProcess(command, extraEnvVars, cwd, stdio);
     default:
       throw new Error(`Unsupported runtime: ${CurrentRuntime}`);
   }

--- a/utils/stdio.ts
+++ b/utils/stdio.ts
@@ -7,13 +7,14 @@ if (CurrentRuntime === Runtime.Bun) {
   // Bun has a bug in Writable.toWeb, so polyfill
   Writable.toWeb = (streamWritable) => {
     return new WritableStream({
-        write(chunk) {
-          streamWritable.write(chunk)
-        },
+      write(chunk) {
+        streamWritable.write(chunk);
+      },
     });
-  }
+  };
 }
 
-export const stdin = () => (Readable.toWeb(process.stdin) as ReadableStream);
-export const stdout = () => Writable.toWeb(process.stdout);
-export const stderr = () => Writable.toWeb(process.stderr);
+// @ts-ignore Node has strange typings on Stream objects
+export const stdin = (): ReadableStream => (Readable.toWeb(process.stdin));
+export const stdout = (): WritableStream => Writable.toWeb(process.stdout);
+export const stderr = (): WritableStream => Writable.toWeb(process.stderr);

--- a/utils/stdio.ts
+++ b/utils/stdio.ts
@@ -14,6 +14,6 @@ if (CurrentRuntime === Runtime.Bun) {
   }
 }
 
-export const stdin = () => Readable.toWeb(process.stdin);
+export const stdin = () => (Readable.toWeb(process.stdin) as ReadableStream);
 export const stdout = () => Writable.toWeb(process.stdout);
 export const stderr = () => Writable.toWeb(process.stderr);

--- a/utils/stdio.ts
+++ b/utils/stdio.ts
@@ -1,0 +1,19 @@
+import { CurrentRuntime, Runtime } from "@cross/runtime";
+
+import process from "node:process";
+import { Readable, Writable } from "node:stream";
+
+if (CurrentRuntime === Runtime.Bun) {
+  // Bun has a bug in Writable.toWeb, so polyfill
+  Writable.toWeb = (streamWritable) => {
+    return new WritableStream({
+        write(chunk) {
+          streamWritable.write(chunk)
+        },
+    });
+  }
+}
+
+export const stdin = () => Readable.toWeb(process.stdin);
+export const stdout = () => Writable.toWeb(process.stdout);
+export const stderr = () => Writable.toWeb(process.stderr);

--- a/utils/stdio.ts
+++ b/utils/stdio.ts
@@ -14,7 +14,21 @@ if (CurrentRuntime === Runtime.Bun) {
   };
 }
 
+/**
+ * Get the stdin as a web-standard `ReadableStream` object.
+ * @returns the stdin stream
+ */
 // @ts-ignore Node has strange typings on Stream objects
-export const stdin = (): ReadableStream => (Readable.toWeb(process.stdin));
+export const stdin = (): ReadableStream => Readable.toWeb(process.stdin);
+
+/**
+ * Get the stdout as a web-standard `WritableStream` object.
+ * @returns the stdout stream
+ */
 export const stdout = (): WritableStream => Writable.toWeb(process.stdout);
+
+/**
+ * Get the stderr as a web-standard `WritableStream` object.
+ * @returns the stderr stream
+ */
 export const stderr = (): WritableStream => Writable.toWeb(process.stderr);

--- a/utils/sysinfo.ts
+++ b/utils/sysinfo.ts
@@ -1,5 +1,6 @@
 import { CurrentRuntime, Runtime } from "@cross/runtime";
 import { freemem, loadavg, totalmem, uptime as nodeUptime } from "node:os";
+import process from "node:process";
 
 /**
  * Provides information about the memory usage of the current process.


### PR DESCRIPTION
This adds the option to pass a `stdio` argument to `spawn()`. This allows you to interact more with the child process. For example, in Deno, you can pass the host process's stdio with:
```ts
import { spawn } from "@cross/utils";

spawn(["<COMMAND>"], {}, undefined, {
  stdin: Deno.stdin.readable,
  stdout: Deno.stdout.writable,
  stderr: Deno.stderr.writable,
});
```
This is fully backwards-compatible - if this argument is omitted it should run identically to the current version of `@cross/utils`.

I also removed the Deno and Bun implementations as both have decent Node compatibility covering `spawn()`, with just one quite small polyfill required in Bun.

Separately, I've also added an `@cross/utils/stdio` module to get the current process's stdio streams more easily across platforms (again, the Node API is mostly compatible with all 3 runtimes, though a small polyfill is again required for Bun) . With this, the above can be rewritten like this:
```ts
import { spawn, stdin, stdout, stderr } from "@cross/utils";

spawn(["<COMMAND>"], {}, undefined, {
  stdin: stdin(),
  stdout: stdout(),
  stderr: stderr(),
});
```